### PR TITLE
fix named export 'contains' is imported as default

### DIFF
--- a/src/helpers/contains.js
+++ b/src/helpers/contains.js
@@ -1,6 +1,6 @@
 // Checks to see if a parent element contains a child element
 /* eslint no-param-reassign:0, no-cond-assign:0 */
-export function contains(parent, child) {
+export default function contains(parent, child) {
   do {
     if (parent === child) {
       return true;


### PR DESCRIPTION
`FlipCard.js` imports `contains` as default
https://github.com/Dash-OS/react-flipcard-2/blob/master/src/components/FlipCard.js#L5

`contains` is exported as a named export
https://github.com/Dash-OS/react-flipcard-2/blob/master/src/helpers/contains.js#L3

This breaks projects that do not transform es6-style modules